### PR TITLE
#8: use single ID for repositories

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -79,12 +79,7 @@ Then you can configure your setup as following:
 ```xml
   <servers>
     <server>
-      <id>release-repository</id>
-      <username>«LOGIN»</username>
-      <password>«ENCRYPTED-PASSWORD»</password>
-    </server>
-    <server>
-      <id>snapshot-repository</id>
+      <id>repository</id>
       <username>«LOGIN»</username>
       <password>«ENCRYPTED-PASSWORD»</password>
     </server>

--- a/pom.xml
+++ b/pom.xml
@@ -548,12 +548,12 @@
 
   <distributionManagement>
     <repository>
-      <id>release-repository</id>
+      <id>repository</id>
       <name>release repository</name>
       <url>${maven.release.repository}</url>
     </repository>
     <snapshotRepository>
-      <id>snapshot-repository</id>
+      <id>repository</id>
       <name>snapshot repository</name>
       <url>${maven.snapshot.repository}</url>
     </snapshotRepository>


### PR DESCRIPTION
Fix for #8: use single ID for repositories