### PR TITLE
change surefire version to 3.0.0-M5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
     <maven.project.info.reports.plugin.version>3.0.0</maven.project.info.reports.plugin.version>
     <maven.jxr.plugin.version>3.0.0</maven.jxr.plugin.version>
     <maven.javadoc.plugin.version>3.1.1</maven.javadoc.plugin.version>
-    <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
-    <maven.surefire.report.plugin.version>2.22.2</maven.surefire.report.plugin.version>
+    <maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
+    <maven.surefire.report.plugin.version>3.0.0-M5</maven.surefire.report.plugin.version>
     <maven.pmd.plugin.version>3.9.0</maven.pmd.plugin.version>
     <maven.war.plugin.version>3.2.3</maven.war.plugin.version>
     <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>


### PR DESCRIPTION
@suvmanda or @lmarniazman can someone add a rationale why we are doing this update?
The M in 3.0.0-M5 stands for milestone so this is a pre-version. If we have some good reasons for this update, I am fine.