### PR TITLE
added maven gpg plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -469,6 +469,13 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <!-- Prevent gpg from using pinentry programs -->
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
This configuration is necessary to avoid the common error "signing failed: Inappropriate ioctl for device" which is thrown when the maven gpg plugin tries to sign artifacts.
In the picture below is an example of the error.
![gpg_inappropriate_ioctl_for_device](https://user-images.githubusercontent.com/98025282/192650285-8733f1f1-39f7-4892-952b-c657601743d1.PNG)
